### PR TITLE
Update link from unofficial nixos wiki to official one

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -31,7 +31,7 @@ where:
 ## Notes
 
 ### Sockets live in `~/emacs.d/sockets` by default
-This is only intended to work with Emacs server daemons with Unix socket files (i.e. not TCP). The socket files belonging to any Emacs daemons from `eud` are stored in a single directory (this shall be made configurable). While this is inconsistent with Emacs' own implementation (which allows for the user to set `server-socket-dir` in their Emacs configuration, _or_ for the socket directory to use the environment `$TMPDIR`, _or_ to fall back to the system default temp. directory (typically `/tmp/emacs$(id -u)`). Currently, the socket directory is set to `~/.emacs.d/sockets/` (which will be created by `eud` if it does not already exist). Using a single location for this, explicitly, has the pleasant side-effect of avoiding unix socket files being strewn around various temporary directories (as can happen when using [`nix-shell`](https://nixos.wiki/wiki/Development_environment_with_nix-shell) environments, for example).
+This is only intended to work with Emacs server daemons with Unix socket files (i.e. not TCP). The socket files belonging to any Emacs daemons from `eud` are stored in a single directory (this shall be made configurable). While this is inconsistent with Emacs' own implementation (which allows for the user to set `server-socket-dir` in their Emacs configuration, _or_ for the socket directory to use the environment `$TMPDIR`, _or_ to fall back to the system default temp. directory (typically `/tmp/emacs$(id -u)`). Currently, the socket directory is set to `~/.emacs.d/sockets/` (which will be created by `eud` if it does not already exist). Using a single location for this, explicitly, has the pleasant side-effect of avoiding unix socket files being strewn around various temporary directories (as can happen when using [`nix-shell`](https://wiki.nixos.org/wiki/Development_environment_with_nix-shell) environments, for example).
 
 If `eud` is installed and available on the `PATH`, adding the short snipped below will ensure Emacs always uses this sockets directory:
 
@@ -61,7 +61,7 @@ If `eud` is installed and available on the `PATH`, adding the short snipped belo
  - [ ] MacOS launchd integration (set default server to launch on login/boot?)
 
  - [ ] `System::new_all()` from `sysinfo` can probably be slimmed-down
- 
+
  - [ ] How about a `new` command that creates an instance specifically for a working directory / project?
 
 


### PR DESCRIPTION
The readme references the old, unofficial wiki. This PR updates the links to point to the new official wiki source, which will be more properly maintained in the future. It's very much a fandom-wiki situation.